### PR TITLE
Scene heading improvements

### DIFF
--- a/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
+++ b/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
@@ -178,16 +178,6 @@ let (|Section|_|) input = //function
   | rest ->
       None
 
-// TODO: Scene heading should also look for a line break before and after. 
-/// Recognizes a SceneHeading (prefixed with INT/EXT, etc. or a single period)
-//let (|SceneHeading|_|) = function
-//  | String.StartsWithAnyCaseInsensitive [ "INT"; "EXT"; "EST"; "INT./EXT."; "INT/EXT"; "I/E" ] heading:string :: rest ->
-//     Some(false, heading, rest)
-//  | String.StartsWith "." heading:string :: rest ->
-//     Some(true, heading, rest) 
-//  | rest ->
-//     None
-
 // TODO: Should we also look for a line break before? 
 let (|SceneHeading|_|) = function
   | String.StartsWithAnyCaseInsensitive [ "INT"; "EXT"; "EST"; "INT./EXT."; "INT/EXT"; "I/E" ] heading:string :: rest ->

--- a/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
+++ b/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
@@ -180,12 +180,24 @@ let (|Section|_|) input = //function
 
 // TODO: Scene heading should also look for a line break before and after. 
 /// Recognizes a SceneHeading (prefixed with INT/EXT, etc. or a single period)
+//let (|SceneHeading|_|) = function
+//  | String.StartsWithAnyCaseInsensitive [ "INT"; "EXT"; "EST"; "INT./EXT."; "INT/EXT"; "I/E" ] heading:string :: rest ->
+//     Some(false, heading, rest)
+//  | String.StartsWith "." heading:string :: rest ->
+//     Some(true, heading, rest) 
+//  | rest ->
+//     None
+
+// TODO: Should we also look for a line break before? 
 let (|SceneHeading|_|) = function
-  // TODO: Make this StartsWithAnyCaseInsensitive
-  | String.StartsWithAny [ "INT"; "EXT"; "EST"; "INT./EXT."; "INT/EXT"; "I/E" ] heading:string :: rest ->
-     Some(false, heading, rest)
+  | String.StartsWithAnyCaseInsensitive [ "INT"; "EXT"; "EST"; "INT./EXT."; "INT/EXT"; "I/E" ] heading:string :: rest ->
+     // look for a line break after the heading
+     if rest.Length = 0 || String.IsNullOrWhiteSpace rest.[0] then
+        Some(false, heading, rest)
+     else
+        None
   | String.StartsWith "." heading:string :: rest ->
-     Some(true, heading, rest) 
+     Some(true, heading, rest)  // forced heading
   | rest ->
      None
 

--- a/Source/FountainSharp/FountainSharp.Parse/FountainSharp.Parse.fsproj
+++ b/Source/FountainSharp/FountainSharp.Parse/FountainSharp.Parse.fsproj
@@ -38,7 +38,7 @@
     <Compile Include="Common\AssemblyInfo.fs" />
     <Compile Include="Collections.fs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
   <ItemGroup>
     <Folder Include="Common\" />
   </ItemGroup>

--- a/Source/FountainSharp/FountainSharp.Parse/FountainSyntaxDefinition.md
+++ b/Source/FountainSharp/FountainSharp.Parse/FountainSyntaxDefinition.md
@@ -31,8 +31,6 @@
 
 # Scene Heading
 
-TODO: Allow lower-case/mixed case scene headings (make string ToUpper first and then compare)
-
 A Scene Heading is any line that has a blank line following it, and either begins with INT or EXT or similar (full list below). A Scene Heading always has at least one blank line preceding it.
 
 Power user: You can "force" a Scene Heading by starting the line with a single period.

--- a/Source/FountainSharp/FountainSharp.Parse/StringParsing.fs
+++ b/Source/FountainSharp/FountainSharp.Parse/StringParsing.fs
@@ -41,6 +41,8 @@ module String =
   /// NOTE: BryanC 2016.01.02 - i added the string return so it's more useful and matches the others
   let (|StartsWithAny|_|) (starts:seq<string>) (text:string) = 
     if starts |> Seq.exists (text.StartsWith) then Some(text) else None
+  let (|StartsWithAnyCaseInsensitive|_|) (starts:seq<string>) (text:string) = 
+    if starts |> Seq.exists (fun s -> text.StartsWith(s, StringComparison.OrdinalIgnoreCase)) then Some(text) else None
   /// Matches when a string starts with the specified sub-string
   let (|StartsWith|_|) (start:string) (text:string) = 
     if text.StartsWith(start) then Some(text.Substring(start.Length)) else None

--- a/Source/FountainSharp/PortableProjects/FountainSharp.Parse.MobilePCL/FountainSharp.Parse.MobilePCL.fsproj
+++ b/Source/FountainSharp/PortableProjects/FountainSharp.Parse.MobilePCL/FountainSharp.Parse.MobilePCL.fsproj
@@ -66,5 +66,5 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.Portable.FSharp.Targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.Portable.FSharp.Targets" />
 </Project>

--- a/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/App.config
+++ b/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainSharp.Parse.Tests.fsproj
+++ b/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainSharp.Parse.Tests.fsproj
@@ -16,18 +16,32 @@
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <Externalconsole>true</Externalconsole>
-    <PlatformTarget></PlatformTarget>
+    <PlatformTarget>
+    </PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <Externalconsole>true</Externalconsole>
     <GenerateTailCalls>true</GenerateTailCalls>
-    <PlatformTarget></PlatformTarget>
+    <PlatformTarget>
+    </PlatformTarget>
   </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
+  <ItemGroup>
+    <Compile Include="FountainTests.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Resources.fs" />
+    <Compile Include="Exec.fs" />
+    <Compile Include="Program.fs" />
+    <EmbeddedResource Include="TestFiles\SimpleTest.fountain" />
+    <None Include="packages.config" />
+    <Content Include="App.config" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
@@ -46,25 +60,6 @@
     <Reference Include="NHamcrest">
       <HintPath>..\..\packages\FsUnit.2.3.1\lib\net45\NHamcrest.dll</HintPath>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="FountainTests.fs" />
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Resources.fs" />
-    <Compile Include="Exec.fs" />
-    <Compile Include="Program.fs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
-  <ItemGroup>
-    <EmbeddedResource Include="TestFiles\SimpleTest.fountain" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="TestFiles\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\PortableProjects\FountainSharp.Parse.MobilePCL\FountainSharp.Parse.MobilePCL.fsproj">
       <Project>{EF7FFC79-964B-41EC-A90F-BBDE329D2DFD}</Project>
       <Name>FountainSharp.Parse.MobilePCL</Name>


### PR DESCRIPTION
Scene heading now supports lowercase/mixed and also watch for empty line after the heading.
Unit tests were already present as I see. Now "Lowercase known scene heading" test also succeeds.
This pr also includes https://github.com/bryancostanich/FountainSharp/commit/58383cb0fd01b75d0c2069719be950af4cf815b5  I have worked on heading issues on my Windows machine and master branch did not compiled (nor the current dev), so I applied this fix before started.