### PR TITLE
Emphasis support

### DIFF
--- a/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
+++ b/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
@@ -179,16 +179,25 @@ let (|Section|_|) input = //function
   | rest ->
       None
 
-// TODO: Should we also look for a line break before? 
-let (|SceneHeading|_|) = function
-  | String.StartsWithAnyCaseInsensitive [ "INT"; "EXT"; "EST"; "INT./EXT."; "INT/EXT"; "I/E" ] heading:string :: rest ->
-     // look for a line break after the heading
+let NewLineAfterFirstElement (forced, list) = 
+  match list with
+  | [] ->
+    None
+  | head::rest ->
+     // look for a line break after the first element (first of the rest)
      if rest.Length = 0 || String.IsNullOrWhiteSpace rest.[0] then
-        Some(false, heading, rest)
+        Some(forced, head, rest)
      else
         None
+
+// TODO: Should we also look for a line break before? 
+let (|SceneHeading|_|) = function
+  // look for normal heading
+  | String.StartsWithAnyCaseInsensitive [ "INT"; "EXT"; "EST"; "INT./EXT."; "INT/EXT"; "I/E" ] heading:string :: rest ->
+     NewLineAfterFirstElement (false, heading :: rest)
+  // look for forced heading
   | String.StartsWith "." heading:string :: rest ->
-     Some(true, heading, rest)  // forced heading
+     NewLineAfterFirstElement (true, heading :: rest)
   | rest ->
      None
 

--- a/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
+++ b/Source/FountainSharp/FountainSharp.Parse/FountainParser.fs
@@ -44,7 +44,7 @@ let (|DelimitedText|_|) delimiterBracket input =
     match input with
     | EscapedChar(x, xs) -> loop (x::'\\'::acc) found xs // skip the escaped char
     | x::xs -> 
-      if List.startsWith endl input then
+      if List.startsWith endl input && Char.IsWhiteSpace acc.Head = false then
         loop (x::acc) true xs // found a delimiter, but we have to found the furthermost
       else
         if found then // now not matching, but in the previous iteration it was ok

--- a/Source/FountainSharp/FountainSharp.Parse/FountainSyntax.fs
+++ b/Source/FountainSharp/FountainSharp.Parse/FountainSyntax.fs
@@ -12,6 +12,8 @@ type Range(location:int,length:int) =
   override this.ToString() =
     sprintf "Location: %d; Length: %d" this.Location this.Length
 
+  static member empty = new Range(0, 0)
+
 /// Represents inline formatting inside a block. This can be literal (with text), various
 /// formattings (string, emphasis, etc.), hyperlinks, etc.
 

--- a/Source/FountainSharp/FountainSharp.Parse/ToDo.md
+++ b/Source/FountainSharp/FountainSharp.Parse/ToDo.md
@@ -2,28 +2,28 @@
 
 ## Add positional support to the parser.
 
-The parser is all right on its own, but to be best used from an editor, each formatted 
-document element (`FountainSpanElement` and `FountainBlockElement`) should also contain 
-its positional/range information, i.e.: `start` and `length` of the element with in the 
+The parser is all right on its own, but to be best used from an editor, each formatted
+document element (`FountainSpanElement` and `FountainBlockElement`) should also contain
+its positional/range information, i.e.: `start` and `length` of the element with in the
 doc.
 
 Range can be:
 
 ```FSharp
 [<Struct>]
-type Range(location:int,length:int) = 
+type Range(location:int,length:int) =
   member this.Location = location
   member this.Length = length
 ```
 
-Both `FountainSpanElement` and `FountainBlockElement` should probably inherit from a 
-base class that is the Range, or has the Range or something. We can't put it directly 
+Both `FountainSpanElement` and `FountainBlockElement` should probably inherit from a
+base class that is the Range, or has the Range or something. We can't put it directly
 on those classes because they're discriminated unions. See:
 
 * [SO Article 1](http://stackoverflow.com/questions/10959335/how-add-setter-to-to-discriminated-unions-in-f)
 * [SO 2](http://stackoverflow.com/questions/1332299/discriminated-union-let-binding)
 
-However, I have some temporary working code checked in right now that has the Range 
+However, I have some temporary working code checked in right now that has the Range
 directly on them, but it should be removed, see:
 
 `FountainSyntax.fs`
@@ -33,7 +33,7 @@ type FountainSpanElement =
   | Strong of FountainSpans * Range // **some bold text**
 ...
 
-type FountainBlockElement = 
+type FountainBlockElement =
   | Action of bool * FountainSpans * Range
   | Character of bool * FountainSpans * Range
 ...
@@ -41,32 +41,29 @@ type FountainBlockElement =
 
 ### Calculating the Range
 
-Because of the nature of parsing routine, it would be very difficult to calculate the 
+Because of the nature of parsing routine, it would be very difficult to calculate the
 range during each element's parsing. Therefore, it probably needs to be calculated at
 the end of the parsing. This means that the Range necessarily needs to be mutable.
 
-I'm open to ideas here, though. Maybe someone smarter than me can do this during 
+I'm open to ideas here, though. Maybe someone smarter than me can do this during
 parsing.
 
 ### Unit Tests + Documentation
 
 Along with the actual range calculation and class modifications, unit tests should be
-created that validate the ranges for all elements. Additionally, the class 
+created that validate the ranges for all elements. Additionally, the class
 modifications themselves should be documented at the class level.
 
 ## Nuget Package Creation
 
-Probably both the FountainSharp.Parse and the FountainSharp.Parse.MobilePCL should be packaged up in a NuGet and published. 
+Probably both the FountainSharp.Parse and the FountainSharp.Parse.MobilePCL should be packaged up in a NuGet and published.
 
 ## Remaining Syntax Support
 
-See [Syntax Definition](FountainSyntaxDefinition.md). Several outstanding syntax 
+See [Syntax Definition](FountainSyntaxDefinition.md). Several outstanding syntax
 items need to be added and/or modified:
 
- * **Character** - Missing support for Parenthetical extensions, e.g. "BOB (OS)" 
-   or "AMY (on the radio)"
-
- * **Dual Dilogue** - Not supported at all yet.
+ * **Dual Dialogue** - Not supported at all yet.
 
  * **Boneyard/Comments** - Not supported at all yet.
 

--- a/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
+++ b/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
@@ -358,28 +358,28 @@ let ``Emphasis - Nested Underline Italic`` () =
 let ``Emphasis - with escapes`` () =
    let doc = "Steel enters the code on the keypad: **\*9765\***" |> Fountain.Parse
    doc.Blocks
-   |> should equal ""//[Action (false, [Literal ("Steel enters the code on the keypad: ", new Range(0,0)), new Range(0,0)]
+   |> should equal [Action (false, [Literal ("Steel enters the code on the keypad: ", new Range(0,0)); Strong ([Literal("*9765*", Range.empty)], Range.empty)], Range.empty)]
 
 [<Test>]
 let ``Emphasis - italics with spaces to left`` () =
+   // this is not italic, as there is a space on the left of the second one
    let doc = "He dialed *69 and then *23, and then hung up." |> Fountain.Parse
    doc.Blocks
-   |> should equal ""//[Action (false, [Literal "He dialed "; Italic [Literal "69 and then "]; Literal "23, and then hung up."])]
+   |> should equal [Action (false, [Literal ("He dialed *69 and then *23, and then hung up.", Range.empty)], Range.empty)]
 
 [<Test>]
 let ``Emphasis - italics with spaces to left but escaped`` () =
    let doc = "He dialed *69 and then 23\*, and then hung up.." |> Fountain.Parse
    doc.Blocks
-   |> should equal ""// [Action (false, [Literal "He dialed *69 and then 23*, and then hung up.."])]
+   |> should equal [Action (false, [Literal( "He dialed *69 and then 23*, and then hung up..", Range.empty)], Range.empty)]
 
-// TODO: are line breaks being recognized properly here? i think not. i think i need more line break cases
 [<Test>]
 let ``Emphasis - between line breaks`` () =
    let doc = "As he rattles off the long list, Brick and Steel *share a look.\r\n\
              \r\n\
              This is going to be BAD.*" |> Fountain.Parse
    doc.Blocks
-   |> should equal ""//[Action (false, [Literal @"As he rattles off the long list, Brick and Steel *share a look."; HardLineBreak(new Range(0,0)); HardLineBreak(new Range(0,0)); Literal "This is going to be BAD.*"])]
+   |> should equal [Action (false, [Literal( "As he rattles off the long list, Brick and Steel *share a look.", Range.empty); HardLineBreak(Range.empty); HardLineBreak(Range.empty); Literal ("This is going to be BAD.*", Range.empty)], Range.empty)]
 
 //===== Indenting
 // TODO

--- a/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
+++ b/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
@@ -342,19 +342,17 @@ let ``Emphasis - Bold Italic`` () =
    doc.Blocks
    |> should equal [Action (false, [Strong ([Italic ([Literal ("This is bold Text", new Range(0,0))], new Range(0,0))], new Range(0,0))], new Range(0,0))]
 
-//TODO: i don't even know how to write this test. it fails anyway. (look at next one, for clues)
 [<Test>]
 let ``Emphasis - Nested Bold Italic`` () =
  let doc = "**This is bold *and Italic Text***" |> Fountain.Parse
  doc.Blocks
-   |> should equal [Action (false, [Literal ("need to figure out how to write the value here.", new Range(0,0))], new Range(0,0))]
-// |> should equal [Action [Strong [Literal "This is bold "] [Italic [Literal "and Italic Text"]]]]
+   |> should equal [Action (false, [Strong ([Literal ("This is bold ", new Range(0,0)); Italic ([Literal ("and Italic Text", new Range(0,0)) ], new Range(0,0)) ], new Range(0,0))], new Range(0,0))]
 
 [<Test>]
-let ``Emphasis - Nested Italic Bold`` () =
+let ``Emphasis - Nested Underline Italic`` () =
    let doc = "From what seems like only INCHES AWAY.  _Steel's face FILLS the *Leupold Mark 4* scope_." |> Fountain.Parse
    doc.Blocks
-   |> should equal ""//[Action (false, [Literal ("From what seems like only INCHES AWAY.  ", new Range(0,0))]; Underline ([Literal ("Steel's face FILLS the ", new Range(0,0)); Italic [Literal ("Leupold Mark 4", new Range(0,0))]; Literal (" scope", new Range(0,0))]; Literal (".", new Range(0,0)), new Range(0,0))]
+   |> should equal [Action (false, [Literal ("From what seems like only INCHES AWAY.  ", new Range(0,0)); Underline ([Literal ("Steel's face FILLS the ", new Range(0,0)); Italic ([Literal ("Leupold Mark 4", new Range(0,0))], new Range(0,0)); Literal (" scope", new Range(0,0))], new Range(0,0)); Literal (".", new Range(0,0))], new Range(0,0))]
 
 [<Test>]
 let ``Emphasis - with escapes`` () =

--- a/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
+++ b/Source/FountainSharp/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
@@ -28,6 +28,26 @@ let ``Forced (".") Scene Heading`` () =
    |> should equal [SceneHeading (true, [Literal ("BINOCULARS A FORCED SCENE HEADING - LATER", new Range(0,0))], new Range(0,0))]
 
 [<Test>]
+let ``Forced (".") Scene Heading with line breaks and action`` () =
+   let heading = "BRICK'S PATIO - DAY";
+   let doc = "." + heading + "\r\n\r\nSome Action" |> Fountain.Parse
+   doc.Blocks
+   |> should equal  [SceneHeading (true, [Literal (heading, new Range(0,0))], new Range(0,0)); Action (false, [HardLineBreak(new Range(0,0)); Literal ("Some Action", new Range(0,0))], new Range(0,0))]
+
+[<Test>]
+let ``Forced (".") Scene Heading with more line breaks and action`` () =
+   let heading = "BRICK'S PATIO - DAY";
+   let doc = "." + heading + "\r\n\r\n\r\nSome Action" |> Fountain.Parse
+   doc.Blocks
+   |> should equal  [SceneHeading (true, [Literal (heading, new Range(0,0))], new Range(0,0)); Action(false, [HardLineBreak(new Range(0,0)); HardLineBreak(new Range(0,0)); Literal("Some Action", new Range(0,0))], new Range(0,0))]
+
+[<Test>]
+let ``Forced (".") Scene Heading - No empty line after`` () =
+   let doc = ".BINOCULARS A FORCED SCENE HEADING - LATER\r\nSome Action" |> Fountain.Parse
+   doc.Blocks
+   |> should equal  [Action (false, [Literal ("BINOCULARS A FORCED SCENE HEADING - LATER", new Range(0,0))], new Range(0,0)); Action (false, [HardLineBreak(new Range(0,0)); Literal ("Some Action", new Range(0,0))], new Range(0,0))]
+
+[<Test>]
 let ``Lowercase known scene heading`` () =
    let doc = "ext. brick's pool - day" |> Fountain.Parse
    doc.Blocks
@@ -75,12 +95,17 @@ let ``Scene Heading with line breaks and action`` () =
    doc.Blocks
    |> should equal  [SceneHeading (false, [Literal ("EXT. BRICK'S PATIO - DAY", new Range(0,0))], new Range(0,0)); Action (false, [HardLineBreak(new Range(0,0)); Literal ("Some Action", new Range(0,0))], new Range(0,0))]
 
-
 [<Test>]
 let ``Scene Heading with more line breaks and action`` () =
    let doc = "EXT. BRICK'S PATIO - DAY\r\n\r\n\r\nSome Action" |> Fountain.Parse
    doc.Blocks
    |> should equal  [SceneHeading (false, [Literal ("EXT. BRICK'S PATIO - DAY", new Range(0,0))], new Range(0,0)); Action(false, [HardLineBreak(new Range(0,0)); HardLineBreak(new Range(0,0)); Literal("Some Action", new Range(0,0))], new Range(0,0))]
+
+[<Test>]
+let ``Scene Heading - No empty line after`` () =
+   let doc = "EXT. BRICK'S PATIO - DAY\r\nSome Action" |> Fountain.Parse
+   doc.Blocks
+   |> should equal  [Action (false, [Literal ("EXT. BRICK'S PATIO - DAY", new Range(0,0))], new Range(0,0)); Action (false, [HardLineBreak(new Range(0,0)); Literal ("Some Action", new Range(0,0))], new Range(0,0))]
 
 //===== Action
 [<Test>]


### PR DESCRIPTION
Completed support of emphasis. All of the emphasis unit tests work as they should.
Added static member empty to Range. IMO Range.empty is way nicer to use than new Range(0, 0).