### PR TITLE
Fixed #2 Html spans now wrap correctly on Firefox and Android browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,8 @@ FakesAssemblies/
 # Visual Studio 6 workspace options file
 *.opt
 tools
+
+*.mfractor
+
+
+.DS_Store

--- a/Source/FountainSharp.Parse/HtmlFormatting.fs
+++ b/Source/FountainSharp.Parse/HtmlFormatting.fs
@@ -80,7 +80,7 @@ module private Html =
     let rec formatSpan (ctx:FormattingContext) = function
       | Literal(str, range) ->
           // preserve white spaces - Action possibly have those
-          ctx.Writer.Write("""<span style="white-space: pre;">""")
+          ctx.Writer.Write("""<span style="white-space: pre-wrap; word-break: keep-all;">""")
           ctx.Writer.Write(if ctx.PreserveWhiteSpace then str else str.Trim())
           ctx.Writer.Write("</span>");
       | HardLineBreak (range) -> ctx.Writer.Write("<br />")

--- a/Source/TestProjects/FountainSharp.Parse.Tests/Bugfixes.fs
+++ b/Source/TestProjects/FountainSharp.Parse.Tests/Bugfixes.fs
@@ -69,3 +69,11 @@ let ``#Bugfix - Scene Heading at the end`` () =
    let doc = properNewLines "\r\nEXT. BRICK'S PATIO - DAY\r\n" |> FountainDocument.Parse
    doc.Blocks
    |> should equal  [SceneHeading (false, [Literal ("EXT. BRICK'S PATIO - DAY", new Range(NewLineLength, 24))], new Range(0, 24 + NewLineLength * 2)) ]
+
+//===== Html Formatter
+[<Test>]
+let ``#Bugfix - Html Spans should wrap correctly on all browsers`` () =
+   let doc = properNewLines "\r\n.BINOCULARS A FORCED SCENE HEADING - LATER\r\n" |> HtmlFormatter.TransformHtml
+   doc |>
+   should contain "white-space: pre-wrap; word-break: keep-all;"
+

--- a/Source/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
+++ b/Source/TestProjects/FountainSharp.Parse.Tests/FountainTests.fs
@@ -1,4 +1,4 @@
-﻿module FountainSharp.Parse.Tests.Unsorted
+module FountainSharp.Parse.Tests.Unsorted
 
 open System
 open FsUnit


### PR DESCRIPTION
Not an F# expert but have included a basic unit test for this fix.