### PR TITLE
Original code was ignoring passed in newline characters

### DIFF
--- a/Source/FountainSharp.Parse/FountainDocument.fs
+++ b/Source/FountainSharp.Parse/FountainDocument.fs
@@ -18,7 +18,7 @@ type FountainDocument(blocks : FountainBlocks, ?text : string) =
   /// inline HTML (etc.) will be stored using the specified string.
   static let parse(text : string, ctx:ParsingContext) =
     let text = properNewLines text
-    let lines = text.Split([|Environment.NewLine|], StringSplitOptions.None) |> List.ofArray
+    let lines = text.Split([|ctx.NewLine|], StringSplitOptions.None) |> List.ofArray
 
     let blocks = 
       lines 


### PR DESCRIPTION
I ran into a stack overflow issue when parsing a document from a mac on a pc.  The new line characters that were being passed in were being ignored.  This allowed me to pass in the new line character.  There may be another approach that auto discovers what the new line characters are based on the file contents, rather than the platform.  I am not experienced enough with F# to figure that out at the moment.